### PR TITLE
lich gone

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -201,11 +201,6 @@
 	category = "Assistance"
 	cost = 1
 
-/datum/spellbook_entry/lichdom
-	name = "Bind Soul"
-	spell_type = /obj/effect/proc_holder/spell/targeted/lichdom
-	category = "Defensive"
-
 /datum/spellbook_entry/teslablast
 	name = "Tesla Blast"
 	spell_type = /obj/effect/proc_holder/spell/targeted/tesla


### PR DESCRIPTION
lich jeopardizes the balance of the game, instead of being it the end of a wizards run when he dies, it's simply a setback and by far one of the most unfun things to play against with modern balance as crew, 4/5 wizards take lich because they know it's overpowered for it's small cost, leading to a massive deathrate in most wizard rounds.

## About The Pull Request

Simply removes it from the spellbook.

## Why It's Good For The Game

Lich was probably made by some idiot who cannot fathom why having an object that respawns a wizard with their full set of gear after 4 minutes as a small or even tiny object was a good idea. It puts them at little dis-advantage and allows the wizard to torment the round for hours. Lichdom would be much better if it made a massive spire as the phylactery and gave the wizard a necromantic stone that passively recharges, acting as a war-mode for wizards.

## Changelog
:cl:
del: Removed lichdom from the normal spells a wizard is able to obtain.
/:cl: