### PR TITLE
Buff the toy dual-saber

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -447,14 +447,16 @@
 	name = "double-bladed toy sword"
 	desc = "A cheap, plastic replica of TWO energy swords.  Double the fun!"
 	force = 0
+	armor_penetration = 100
 	throwforce = 0
-	throw_speed = 3
+	throw_speed = 5
 	throw_range = 5
-	two_hand_force = 0
-	attack_verb_continuous = list("attacks", "strikes", "hits")
-	attack_verb_simple = list("attack", "strike", "hit")
+	two_hand_force = 1
+	sharpness = SHARP_EDGED
+	attack_verb_continuous = list("cleaves", "slices", "chops")
+	attack_verb_simple = list("cleave", "slice", "chop")
 
-/obj/item/dualsaber/toy/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+/obj/item/dualsaber/toy/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 1, attack_type = MELEE_ATTACK)
 	return 0
 
 /obj/item/dualsaber/toy/IsReflect() //Stops Toy Dualsabers from reflecting energy projectiles

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -447,7 +447,6 @@
 	name = "double-bladed toy sword"
 	desc = "A cheap, plastic replica of TWO energy swords.  Double the fun!"
 	force = 0
-	armor_penetration = 100
 	throwforce = 0
 	throw_speed = 5
 	throw_range = 5


### PR DESCRIPTION
Gives it 1 force, makes it sharp, and gives it 100 armor piercing, as well as changing the attack verbs to fit the sharpness. The sharp flag lets it be used as a ghetto scalpel in surgery, among other things (butchering, ect.)

Truly, the future of toys.

## Changelog
:cl:
balance: Buff dualsaber (add sharp to it, make it do 1 brute damage per attack with 100AP)
/:cl:

I didn't buff the normal toy saber, because you can craft it easily. Dual-sabre is only from Donksoft hacked vendors, which only appear through the Lavaland Syndicate base, or through illegal technologies, thus making it a rarer item than the normal sword.