### PR TITLE
Nerfed cryosting

### DIFF
--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -240,5 +240,5 @@
 /datum/action/changeling/sting/cryo/sting_action(mob/user, mob/target)
 	log_combat(user, target, "stung", "cryo sting")
 	if(target.reagents)
-		target.reagents.add_reagent(/datum/reagent/consumable/frostoil, 30)
+		target.reagents.add_reagent(/datum/reagent/consumable/frostoil, 15)
 	return TRUE


### PR DESCRIPTION

## About The Pull Request

Halved the amount of frost oil Cryogenic Sting gives.

Before it was enough to down you from full health to 0. get healed and resuscitated. and then down you again from full health to 0. Now it can only do that once.

## Why It's Good For The Game

Cryogenic sting was a 2x insta-kill ability, now it is only 1x  insta-kill button. much more balanced

## Changelog
:cl:
balance: Nerfed Cryogenic Sting
/:cl:
